### PR TITLE
fixed dacfactoryproxy

### DIFF
--- a/packages/smart-contracts/artifacts/DACProxyFactory.json
+++ b/packages/smart-contracts/artifacts/DACProxyFactory.json
@@ -7010,8 +7010,8 @@
         }
       },
       "links": {},
-      "address": "0x572bfabaeb0f7F5d65EEa04D85595010756Ba986",
-      "transactionHash": "0x3db794499693b153423023016176177e7fbd746f068e24d3f4a8a18a2c2688d2"
+      "address": "0xc35cbaD2c984f30895Bf0AD372805817dD5975f7",
+      "transactionHash": "0x090a60b06e82b52b9a49e7f0a112429df5c0ea86bb8d230669f12ebc0fbdd13d"
     }
   },
   "schemaVersion": "3.0.23",

--- a/packages/smart-contracts/artifacts/DeployedAddresses.json
+++ b/packages/smart-contracts/artifacts/DeployedAddresses.json
@@ -1,1 +1,8 @@
-{"dacProxyFactoryAddress":"0x572bfabaeb0f7F5d65EEa04D85595010756Ba986","dedgeCompoundManagerAddress":"0x16493dfB0281bA27C8B712f6Eb8eC32bcc50EAEc","dedgeMakerManagerAddress":"0x1C9c3ED6De13F423a4457aCCfa4e09bc436D5e89","dedgeExitManagerAddress":"0x81BFDCF729B5cAC3c4f1F906b63F26E5865b615B","dedgeGeneralManagerAddress":"0x40b4C8B5EE1FDd5259E40907E257f11819681b3d","addressRegistryAddress":"0x584d265d2b2c221676137d930A96458B8C30199F"}
+{
+  "dacProxyFactoryAddress": "0xc35cbaD2c984f30895Bf0AD372805817dD5975f7",
+  "dedgeCompoundManagerAddress": "0x16493dfB0281bA27C8B712f6Eb8eC32bcc50EAEc",
+  "dedgeMakerManagerAddress": "0x1C9c3ED6De13F423a4457aCCfa4e09bc436D5e89",
+  "dedgeExitManagerAddress": "0x81BFDCF729B5cAC3c4f1F906b63F26E5865b615B",
+  "dedgeGeneralManagerAddress": "0x40b4C8B5EE1FDd5259E40907E257f11819681b3d",
+  "addressRegistryAddress": "0x584d265d2b2c221676137d930A96458B8C30199F"
+}

--- a/packages/smart-contracts/helpers/exit.ts
+++ b/packages/smart-contracts/helpers/exit.ts
@@ -87,7 +87,7 @@ const getExitPositionParameters = async (
       .map((x: [Address, BigNumber]) => getTokenToEthPrice(x[0], x[1]))
   );
 
-  const ethersToBorrow = debtInEth.reduce((a, b) => a + b)
+  const ethersToBorrow = debtInEth.reduce((a, b) => a.add(b), new BigNumber(0))
 
   return {
     etherToBorrowWeiBN: ethersToBorrow,


### PR DESCRIPTION
Had to redeploy `DACProxyFactory` due to some verification issues on etherscan

```json
{
  "dacProxyFactoryAddress": "0xc35cbaD2c984f30895Bf0AD372805817dD5975f7",
  "dedgeCompoundManagerAddress": "0x16493dfB0281bA27C8B712f6Eb8eC32bcc50EAEc",
  "dedgeMakerManagerAddress": "0x1C9c3ED6De13F423a4457aCCfa4e09bc436D5e89",
  "dedgeExitManagerAddress": "0x81BFDCF729B5cAC3c4f1F906b63F26E5865b615B",
  "dedgeGeneralManagerAddress": "0x40b4C8B5EE1FDd5259E40907E257f11819681b3d",
  "addressRegistryAddress": "0x584d265d2b2c221676137d930A96458B8C30199F"
}
```

EDIT: Ignore this PR, the new address reverts for some reason after deploying it from remix, truffle was doing it correctly