### PR TITLE
import vault(s) allowed bug

### DIFF
--- a/packages/frontend/features/import-vault/useAllowVaultTransfer.ts
+++ b/packages/frontend/features/import-vault/useAllowVaultTransfer.ts
@@ -18,6 +18,8 @@ const useAllowVaultTransfer = (selectedVaultId: number) => {
   const getAllowStatus = async () => {
     const { makerCdpManager } = contracts;
 
+    setImportAllowed(false);
+
     const allowed = await dedgeHelpers.maker.isUserAllowedVault(
       proxy.address,
       selectedVaultId,


### PR DESCRIPTION
If we're importing multiple vaults and the `isUserAllowedVault` check isn't quick enough, the vault would be "allowed" by default.