### PR TITLE
added option to clear dust

### DIFF
--- a/packages/frontend/containers/Contracts.tsx
+++ b/packages/frontend/containers/Contracts.tsx
@@ -12,6 +12,8 @@ import dedgeMakerManager from "../../smart-contracts/artifacts/DedgeMakerManager
 import dedgeExitManager from "../../smart-contracts/artifacts/DedgeExitManager.json";
 
 const CONTRACTS = {
+  compoundComptroller: legos.compound.comptroller,
+  compoundPriceOracle: legos.compound.priceOracle,
   makerProxyRegistry: legos.maker.proxyRegistry,
   makerProxyActions: legos.maker.dssProxyActions,
   makerCdpManager: legos.maker.dssCdpManager,

--- a/packages/frontend/features/swap-tokens/ClearDust.tsx
+++ b/packages/frontend/features/swap-tokens/ClearDust.tsx
@@ -1,0 +1,203 @@
+import { Box, Text, Field, Input, Link, Loader } from "rimble-ui";
+
+import Select from "../../components/Select";
+import ClearDustConfirm from "./ClearDustConfirm";
+
+import DACProxyContainer from "../../containers/DACProxy";
+import ContractContainer from "../../containers/Contracts";
+import CompoundPositions from "../../containers/CompoundPositions";
+import CoinsContainer from "../../containers/Coins";
+
+import { useState, useEffect } from "react";
+import useDustCanSwapAmount from "./useDustCanSwapAmount";
+
+const ClearDust = () => {
+  const { contracts } = ContractContainer.useContainer();
+  const { compoundPositions } = CompoundPositions.useContainer();
+  const { proxyAddress, hasProxy } = DACProxyContainer.useContainer();
+  const { COINS, stableCoins, volatileCoins } = CoinsContainer.useContainer();
+
+  const [thingToClear, setThingToClear] = useState("debt");
+  const [fromTokenStr, setFromTokenStr] = useState("dai");
+  const [toTokenStr, setToTokenStr] = useState("eth");
+  const [amountToClear, setAmountToClear] = useState("");
+
+  const [gettingMax, setGettingMax] = useState(false);
+  const [isConfirmDisabled, setIsConfirmDisabled] = useState(true);
+
+  const tokenBalance =
+    compoundPositions[fromTokenStr] === undefined
+      ? null
+      : thingToClear === "debt"
+      ? compoundPositions[fromTokenStr].borrow
+      : compoundPositions[fromTokenStr].supply;
+
+  const getClearDustInfo = async () => {
+    if (!hasProxy) return;
+    if (tokenBalance === null) return
+
+    setGettingMax(true);
+    const cTokenAddress = COINS[fromTokenStr].cTokenEquilaventAddress;
+
+    const { compoundComptroller, compoundPriceOracle } = contracts;
+
+    const { canSwapAmount } = await useDustCanSwapAmount(
+      thingToClear,
+      proxyAddress,
+      cTokenAddress,
+      tokenBalance,
+      compoundPositions[fromTokenStr].decimals,
+      compoundComptroller,
+      compoundPriceOracle
+    );
+
+    const amountFloat = parseFloat(amountToClear);
+
+    const disableConfirm =
+      !hasProxy || // not connected or no smart wallet
+      fromTokenStr === toTokenStr || // same token
+      amountFloat > tokenBalance || // can't swap more than what you have
+      amountToClear === "" || // no amount specified
+      amountFloat.toString() === "0" ||
+      isNaN(amountFloat);
+
+    setIsConfirmDisabled(disableConfirm);
+    setAmountToClear(canSwapAmount.toString());
+    setGettingMax(false);
+  };
+
+  useEffect(() => {
+    if (hasProxy && tokenBalance !== null) {
+      getClearDustInfo();
+    }
+  }, [
+    hasProxy,
+    thingToClear,
+    fromTokenStr,
+    toTokenStr,
+    hasProxy,
+    amountToClear,
+  ]);
+
+  return (
+    <>
+      <Box>
+        <Field label="I would like to clear dust of" width="100%">
+          <Select
+            required
+            onChange={(e) => setThingToClear(e.target.value)}
+            value={thingToClear}
+          >
+            <option value="debt">Debt (borrowed)</option>
+            <option value="collateral">Collateral (supplied)</option>
+          </Select>
+        </Field>
+      </Box>
+
+      <Box>
+        <Field label="From" width="100%">
+          <Select
+            required
+            value={fromTokenStr}
+            onChange={(e) => setFromTokenStr(e.target.value)}
+          >
+            <optgroup label="Volatile Crypto">
+              {volatileCoins.map((coin) => {
+                const { key, name } = coin;
+                return (
+                  <option key={key} value={key}>
+                    {name}
+                  </option>
+                );
+              })}
+            </optgroup>
+            <optgroup label="Stablecoin">
+              {stableCoins.map((coin) => {
+                const { key, name } = coin;
+                return (
+                  <option key={key} value={key}>
+                    {name}
+                  </option>
+                );
+              })}
+            </optgroup>
+          </Select>
+        </Field>
+      </Box>
+
+      <Box>
+        <Field label="To" width="100%">
+          <Select
+            required
+            value={toTokenStr}
+            onChange={(e) => setToTokenStr(e.target.value)}
+          >
+            <optgroup label="Volatile Crypto">
+              {volatileCoins.map((coin) => {
+                const { key, name } = coin;
+                return (
+                  <option key={key} value={key} disabled={key === fromTokenStr}>
+                    {name}
+                  </option>
+                );
+              })}
+            </optgroup>
+            <optgroup label="Stablecoin">
+              {stableCoins.map((coin) => {
+                const { key, name } = coin;
+                return (
+                  <option key={key} value={key} disabled={key === fromTokenStr}>
+                    {name}
+                  </option>
+                );
+              })}
+            </optgroup>
+          </Select>
+        </Field>
+      </Box>
+
+      <Box mb="3">
+        <Field
+          mb="0"
+          label={`Amount of ${fromTokenStr.toLocaleUpperCase()} dust to clear`}
+        >
+          <Input
+            type="number"
+            required={true}
+            placeholder="1337"
+            value={amountToClear}
+          />
+        </Field>
+        <Text textAlign="right" opacity={!hasProxy ? "0.5" : "1"}>
+          {gettingMax ? (
+            <div
+              style={{
+                float: "right",
+                paddingTop: "4px",
+                paddingBottom: "20px",
+              }}
+            >
+              <Loader />
+            </div>
+          ) : (
+            <div
+              style={{
+                paddingBottom: "24px",
+              }}
+            ></div>
+          )}
+        </Text>
+      </Box>
+
+      <ClearDustConfirm
+        thingToClear={thingToClear}
+        fromTokenStr={fromTokenStr}
+        toTokenStr={toTokenStr}
+        amountToClear={amountToClear}
+        disabled={isConfirmDisabled}
+        outline={!hasProxy}
+      />
+    </>
+  );
+};
+export default ClearDust;

--- a/packages/frontend/features/swap-tokens/ClearDustConfirm.tsx
+++ b/packages/frontend/features/swap-tokens/ClearDustConfirm.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import {
+  Box,
+  Flex,
+  Loader,
+  Modal,
+  Text,
+  Button,
+  Heading,
+  Card,
+  Icon,
+} from "rimble-ui";
+
+import { ModalBottom, ModalCloseIcon } from "../../components/Modal";
+
+import CoinsContainer from "../../containers/Coins";
+import useClearDust from "./useClearDust";
+import CompoundPositions from "../../containers/CompoundPositions";
+
+const ClearDustConfirm = ({
+  thingToClear,
+  fromTokenStr,
+  toTokenStr,
+  amountToClear,
+  disabled,
+  outline,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openModal = () => setIsOpen(true);
+  const closeModal = () => setIsOpen(false);
+
+  const { COINS } = CoinsContainer.useContainer();
+  const { getBalances } = CompoundPositions.useContainer();
+  const { clearDustFunction, loading } = useClearDust(
+    thingToClear,
+    fromTokenStr,
+    toTokenStr,
+    amountToClear,
+  );
+
+  const fromToken = COINS[fromTokenStr];
+  const toToken = COINS[toTokenStr];
+
+  const MyButton = outline ? Button.Outline : Button;
+
+  return (
+    <Box>
+      <MyButton width="100%" onClick={openModal} disabled={disabled}>
+        <Flex alignItems="center">
+          <span>Confirm</span>
+          <Icon name="Launch" color={outline ? "primary" : "white"} ml="2" />
+        </Flex>
+      </MyButton>
+
+      {thingToClear === "debt" && (
+        <>
+          <Text fontSize="0" color="#999" fontWeight="bold" mt="2">
+            Due to nature of slippages:
+          </Text>
+          <Text fontSize="0" color="#999">
+            MAX: 95% (90% recommended)
+          </Text>
+        </>
+      )}
+
+      <Modal isOpen={isOpen}>
+        <Card width={"640px"} p={0}>
+          <ModalCloseIcon onClick={closeModal} />
+
+          <Box p={4} pb={1}>
+            <Heading.h3 mb="4">
+              Clear dust ({thingToClear}) from {fromToken.symbol} to {toToken.symbol}
+            </Heading.h3>
+
+            <Box mb="4">
+              <Heading.h5 mb="2">Please confirm that you want to:</Heading.h5>
+              <Text>
+                Clear {amountToClear} {fromToken.symbol} of {thingToClear} dust to{" "}
+                {toToken.symbol}
+              </Text>
+            </Box>
+          </Box>
+
+          <ModalBottom>
+            <Button.Outline onClick={closeModal}>Close</Button.Outline>
+            <Button
+              ml={3}
+              disabled={loading}
+              onClick={async () => {
+                await clearDustFunction();
+                getBalances();
+                closeModal();
+              }}
+            >
+              {loading ? (
+                <Flex alignItems="center">
+                  <span>Clearing dust...</span> <Loader color="white" ml="2" />
+                </Flex>
+              ) : (
+                "Clear Dust"
+              )}
+            </Button>
+          </ModalBottom>
+        </Card>
+      </Modal>
+    </Box>
+  );
+};
+
+export default ClearDustConfirm;

--- a/packages/frontend/features/swap-tokens/Swap.tsx
+++ b/packages/frontend/features/swap-tokens/Swap.tsx
@@ -1,0 +1,150 @@
+import {
+  Box,
+  Text,
+  Field,
+  Input,
+  Link
+} from "rimble-ui";
+
+import Select from "../../components/Select";
+import SwapConfirm from "./SwapConfirm";
+
+import DACProxyContainer from "../../containers/DACProxy";
+import { useState } from "react";
+import CoinsContainer from "../../containers/Coins";
+import useIsAmountAvailable from "./useIsAmountAvailable";
+
+const Swap = () => {
+  const { hasProxy } = DACProxyContainer.useContainer();
+  const { stableCoins, volatileCoins } = CoinsContainer.useContainer();
+
+  const [thingToSwap, setThingToSwap] = useState("debt");
+  const [fromTokenStr, setFromTokenStr] = useState("dai");
+  const [toTokenStr, setToTokenStr] = useState("eth");
+  const [amountToSwap, setAmountToSwap] = useState("");
+
+  const { isAmountAvailable, canSwapAmount } = useIsAmountAvailable(
+    amountToSwap,
+    fromTokenStr,
+    thingToSwap
+  );
+
+  const disableConfirm =
+    !hasProxy || // not connected or no smart wallet
+    fromTokenStr === toTokenStr || // same token
+    !isAmountAvailable || // amount not available
+    amountToSwap === "" || // no amount specified
+    amountToSwap === "0";
+
+  const setMax = () => {
+    if (!hasProxy) return;
+    setAmountToSwap(canSwapAmount.toString());
+  };
+
+  return (
+    <>
+      <Box>
+        <Field label="I would like to swap" width="100%">
+          <Select
+            required
+            onChange={(e) => setThingToSwap(e.target.value)}
+            value={thingToSwap}
+          >
+            <option value="debt">Debt (borrowed)</option>
+            <option value="collateral">Collateral (supplied)</option>
+          </Select>
+        </Field>
+      </Box>
+
+      <Box>
+        <Field label="From" width="100%">
+          <Select
+            required
+            value={fromTokenStr}
+            onChange={(e) => setFromTokenStr(e.target.value)}
+          >
+            <optgroup label="Volatile Crypto">
+              {volatileCoins.map((coin) => {
+                const { key, name } = coin;
+                return (
+                  <option key={key} value={key}>
+                    {name}
+                  </option>
+                );
+              })}
+            </optgroup>
+            <optgroup label="Stablecoin">
+              {stableCoins.map((coin) => {
+                const { key, name } = coin;
+                return (
+                  <option key={key} value={key}>
+                    {name}
+                  </option>
+                );
+              })}
+            </optgroup>
+          </Select>
+        </Field>
+      </Box>
+
+      <Box>
+        <Field label="To" width="100%">
+          <Select
+            required
+            value={toTokenStr}
+            onChange={(e) => setToTokenStr(e.target.value)}
+          >
+            <optgroup label="Volatile Crypto">
+              {volatileCoins.map((coin) => {
+                const { key, name } = coin;
+                return (
+                  <option key={key} value={key} disabled={key === fromTokenStr}>
+                    {name}
+                  </option>
+                );
+              })}
+            </optgroup>
+            <optgroup label="Stablecoin">
+              {stableCoins.map((coin) => {
+                const { key, name } = coin;
+                return (
+                  <option key={key} value={key} disabled={key === fromTokenStr}>
+                    {name}
+                  </option>
+                );
+              })}
+            </optgroup>
+          </Select>
+        </Field>
+      </Box>
+
+      <Box mb="3">
+        <Field
+          mb="0"
+          label={`Amount of ${fromTokenStr.toLocaleUpperCase()} to swap`}
+        >
+          <Input
+            type="number"
+            required={true}
+            placeholder="1337"
+            value={amountToSwap}
+            onChange={(e) => setAmountToSwap(e.target.value.toString())}
+          />
+        </Field>
+        <Text textAlign="right" opacity={!hasProxy ? "0.5" : "1"}>
+          <Link onClick={setMax}>Set max</Link>
+        </Text>
+      </Box>
+
+      <SwapConfirm
+        thingToSwap={thingToSwap}
+        fromTokenStr={fromTokenStr}
+        toTokenStr={toTokenStr}
+        amountToSwap={amountToSwap}
+        disabled={disableConfirm}
+        outline={!hasProxy}
+      />
+    </>
+  );
+};
+export default Swap;

--- a/packages/frontend/features/swap-tokens/SwapOptions.tsx
+++ b/packages/frontend/features/swap-tokens/SwapOptions.tsx
@@ -1,13 +1,10 @@
-import { Box, Text, Field, Input, Link, Tooltip } from "rimble-ui";
+import { Box, Flex, Button, Pill } from "rimble-ui";
 import styled from "styled-components";
 
-import Select from "../../components/Select";
-import SwapConfirm from "./SwapConfirm";
-
-import DACProxyContainer from "../../containers/DACProxy";
 import { useState } from "react";
-import CoinsContainer from "../../containers/Coins";
-import useIsAmountAvailable from "./useIsAmountAvailable";
+
+import Swap from "./Swap";
+import ClearDust from "./ClearDust";
 
 const Container = styled(Box)`
   margin-right: 16px;
@@ -15,136 +12,50 @@ const Container = styled(Box)`
     -1px 0px rgba(250, 180, 40, 0.5);
 `;
 
+enum SWAP_TAB_OPTIONS {
+  Swap,
+  ClearDust,
+}
+
 const SwapOptions = () => {
-  const { hasProxy } = DACProxyContainer.useContainer();
-  const { stableCoins, volatileCoins } = CoinsContainer.useContainer();
-
-  const [thingToSwap, setThingToSwap] = useState("debt");
-  const [fromTokenStr, setFromTokenStr] = useState("dai");
-  const [toTokenStr, setToTokenStr] = useState("eth");
-  const [amountToSwap, setAmountToSwap] = useState("");
-
-  const { isAmountAvailable, canSwapAmount } = useIsAmountAvailable(
-    amountToSwap,
-    fromTokenStr,
-    thingToSwap,
-  );
-
-  const disableConfirm =
-    !hasProxy || // not connected or no smart wallet
-    fromTokenStr === toTokenStr || // same token
-    !isAmountAvailable || // amount not available
-    amountToSwap === "" || // no amount specified
-    amountToSwap === "0";
-
-  const setMax = () => {
-    if (!hasProxy) return;
-    setAmountToSwap(canSwapAmount.toString());
-  };
+  const [selectedTab, setSelectedTab] = useState(SWAP_TAB_OPTIONS.Swap);
 
   return (
     <Container p="3">
-      <Box>
-        <Field label="I would like to swap" width="100%">
-          <Select
-            required
-            onChange={e => setThingToSwap(e.target.value)}
-            value={thingToSwap}
-          >
-            <option value="debt">Debt (borrowed)</option>
-            <option value="collateral">Collateral (supplied)</option>
-          </Select>
-        </Field>
+      <Box m="auto">
+        <Flex borderColor="#E8E8E8" justifyContent="center">
+          <Box my={3} textAlign="center">
+            {selectedTab === SWAP_TAB_OPTIONS.Swap ? (
+              <Pill mt={2} color="primary">
+                <Button.Text mainColor="#110C62">Swap</Button.Text>
+              </Pill>
+            ) : (
+              <Button.Text
+                mainColor="#988CF0"
+                onClick={() => setSelectedTab(SWAP_TAB_OPTIONS.Swap)}
+              >
+                Swap
+              </Button.Text>
+            )}
+            {selectedTab === SWAP_TAB_OPTIONS.ClearDust ? (
+              <Pill mt={2} color="primary">
+                <Button.Text mainColor="#110C62">Clear Dust</Button.Text>
+              </Pill>
+            ) : (
+              <Button.Text
+                mainColor="#988CF0"
+                onClick={() => setSelectedTab(SWAP_TAB_OPTIONS.ClearDust)}
+              >
+                Clear Dust
+              </Button.Text>
+            )}
+          </Box>
+        </Flex>
       </Box>
 
-      <Box>
-        <Field label="From" width="100%">
-          <Select
-            required
-            value={fromTokenStr}
-            onChange={e => setFromTokenStr(e.target.value)}
-          >
-            <optgroup label="Volatile Crypto">
-              {volatileCoins.map(coin => {
-                const { key, name } = coin;
-                return (
-                  <option key={key} value={key}>
-                    {name}
-                  </option>
-                );
-              })}
-            </optgroup>
-            <optgroup label="Stablecoin">
-              {stableCoins.map(coin => {
-                const { key, name } = coin;
-                return (
-                  <option key={key} value={key}>
-                    {name}
-                  </option>
-                );
-              })}
-            </optgroup>
-          </Select>
-        </Field>
-      </Box>
+      {selectedTab === SWAP_TAB_OPTIONS.Swap ? <Swap /> : null}
+      {selectedTab === SWAP_TAB_OPTIONS.ClearDust ? <ClearDust /> : null}
 
-      <Box>
-        <Field label="To" width="100%">
-          <Select
-            required
-            value={toTokenStr}
-            onChange={e => setToTokenStr(e.target.value)}
-          >
-            <optgroup label="Volatile Crypto">
-              {volatileCoins.map(coin => {
-                const { key, name } = coin;
-                return (
-                  <option key={key} value={key} disabled={key === fromTokenStr}>
-                    {name}
-                  </option>
-                );
-              })}
-            </optgroup>
-            <optgroup label="Stablecoin">
-              {stableCoins.map(coin => {
-                const { key, name } = coin;
-                return (
-                  <option key={key} value={key} disabled={key === fromTokenStr}>
-                    {name}
-                  </option>
-                );
-              })}
-            </optgroup>
-          </Select>
-        </Field>
-      </Box>
-
-      <Box mb="3">
-        <Field
-          mb="0"
-          label={`Amount of ${fromTokenStr.toLocaleUpperCase()} to swap`}
-        >
-          <Input
-            type="number"
-            required={true}
-            placeholder="1337"
-            value={amountToSwap}
-            onChange={e => setAmountToSwap(e.target.value.toString())}
-          />
-        </Field>
-        <Text textAlign="right" opacity={!hasProxy ? "0.5" : "1"}>
-          <Link onClick={setMax}>Set max</Link>
-        </Text>
-      </Box>
-
-      <SwapConfirm
-        thingToSwap={thingToSwap}
-        fromTokenStr={fromTokenStr}
-        toTokenStr={toTokenStr}
-        amountToSwap={amountToSwap}
-        disabled={disableConfirm}
-        outline={!hasProxy}
-      />
     </Container>
   );
 };

--- a/packages/frontend/features/swap-tokens/useClearDust.ts
+++ b/packages/frontend/features/swap-tokens/useClearDust.ts
@@ -1,0 +1,110 @@
+import useClearDustOperation from "./useClearDustOperation";
+import ContractsContainer from "../../containers/Contracts";
+import CoinContainer from "../../containers/Coins";
+import { ethers } from "ethers";
+import { Wei } from "../../types";
+import { useState } from "react";
+
+const inWei = (x: string, u = 18): Wei => ethers.utils.parseUnits(x, u);
+
+const useSwap = (thingToClear, fromTokenStr, toTokenStr, amountToClear) => {
+  const { COINS } = CoinContainer.useContainer();
+  const { contracts } = ContractsContainer.useContainer();
+  const { clearDustCollateral, clearDustDebt } = useClearDustOperation();
+  const [loading, setLoading] = useState(false);
+
+  const clearDustFunction = async () => {
+    setLoading(true);
+    const { cEther, cDai, cBat, cUsdc, cRep, cZrx, cWbtc } = contracts;
+
+    const COINS_ADDRESS_DECIMALS_MAP = {
+      [COINS.eth.symbol.toLowerCase()]: COINS.eth.decimals,
+      [COINS.dai.symbol.toLowerCase()]: COINS.dai.decimals,
+      [COINS.bat.symbol.toLowerCase()]: COINS.bat.decimals,
+      [COINS.usdc.symbol.toLowerCase()]: COINS.usdc.decimals,
+      [COINS.rep.symbol.toLowerCase()]: COINS.rep.decimals,
+      [COINS.zrx.symbol.toLowerCase()]: COINS.zrx.decimals,
+      [COINS.wbtc.symbol.toLowerCase()]: COINS.wbtc.decimals,
+    };
+
+    const amount: Wei = inWei(
+      amountToClear,
+      COINS_ADDRESS_DECIMALS_MAP[fromTokenStr.toLowerCase()]
+    );
+
+    const ADDRESS_MAP = {
+      eth: cEther.address,
+      bat: cBat.address,
+      dai: cDai.address,
+      usdc: cUsdc.address,
+      rep: cRep.address,
+      zrx: cZrx.address,
+      wbtc: cWbtc.address,
+    };
+
+    // perform swap debt
+    if (thingToClear === "debt") {
+      window.analytics.track("Clear Dust Start", {
+        from: fromTokenStr,
+        to: toTokenStr,
+        amount: amountToClear,
+      });
+      const tx = await clearDustDebt(
+        ADDRESS_MAP[fromTokenStr],
+        ADDRESS_MAP[toTokenStr],
+        amount
+      );
+      window.toastProvider.addMessage(`Clearing dust (debt)...`, {
+        secondaryMessage: "Check progress on Etherscan",
+        actionHref: `https://etherscan.io/tx/${tx.hash}`,
+        actionText: "Check",
+        variant: "processing",
+      });
+      await tx.wait();
+      setLoading(false);
+      window.toastProvider.addMessage(`Clear Dust (Debt) Success!`, {
+        variant: "success",
+      });
+      window.analytics.track("Clear Dust (Debt) Success", {
+        from: fromTokenStr,
+        to: toTokenStr,
+        amount: amountToClear,
+      });
+      return;
+    }
+
+    // perform swap collateral
+    window.analytics.track("Clearing Dust (Collateral) Start", {
+      from: fromTokenStr,
+      to: toTokenStr,
+      amount: amountToClear,
+    });
+    const tx = await clearDustCollateral(
+      ADDRESS_MAP[fromTokenStr],
+      ADDRESS_MAP[toTokenStr],
+      amount
+    );
+    window.toastProvider.addMessage(`Clearing dust (collateral)...`, {
+      secondaryMessage: "Check progress on Etherscan",
+      actionHref: `https://etherscan.io/tx/${tx.hash}`,
+      actionText: "Check",
+      variant: "processing",
+    });
+    await tx.wait();
+
+    window.toastProvider.addMessage(`Clear dust (collateral) success!`, {
+      variant: "success",
+    });
+    window.analytics.track("Clear Dust (Collateral) Success", {
+      from: fromTokenStr,
+      to: toTokenStr,
+      amount: amountToClear,
+    });
+    setLoading(false);
+    return;
+  };
+
+  return { clearDustFunction, loading };
+};
+
+export default useSwap;

--- a/packages/frontend/features/swap-tokens/useClearDustOperation.ts
+++ b/packages/frontend/features/swap-tokens/useClearDustOperation.ts
@@ -4,18 +4,18 @@ import DACProxyContainer from "../../containers/DACProxy";
 import { dedgeHelpers } from "../../../smart-contracts/dist/helpers";
 import { Address, Wei } from "../../types";
 
-const useSwapOperation = () => {
+const useClearDustOperation = () => {
   const { contracts } = ContractsContainer.useContainer();
   const { proxy } = DACProxyContainer.useContainer();
 
-  const swapDebt = async (
+  const clearDustCollateral = async (
     fromCToken: Address,
     toCToken: Address,
     fromCTokenUnderlyingDelta: Wei,
   ) => {
     const { dedgeCompoundManager, dedgeAddressRegistry } = contracts;
 
-    return dedgeHelpers.compound.swapDebt(
+    return dedgeHelpers.compound.clearDustCollateral(
       proxy,
       dedgeCompoundManager.address,
       dedgeAddressRegistry.address,
@@ -25,14 +25,14 @@ const useSwapOperation = () => {
     );
   };
 
-  const swapCollateral = async (
+  const clearDustDebt = async (
     fromCToken: Address,
     toCToken: Address,
     fromCTokenUnderlyingDelta: Wei,
   ) => {
     const { dedgeCompoundManager, dedgeAddressRegistry } = contracts;
 
-    return dedgeHelpers.compound.swapCollateral(
+    return dedgeHelpers.compound.clearDustDebt(
       proxy,
       dedgeCompoundManager.address,
       dedgeAddressRegistry.address,
@@ -42,7 +42,7 @@ const useSwapOperation = () => {
     );
   };
 
-  return { swapDebt, swapCollateral };
+  return { clearDustDebt, clearDustCollateral };
 };
 
-export default useSwapOperation;
+export default useClearDustOperation;

--- a/packages/frontend/features/swap-tokens/useDustCanSwapAmount.ts
+++ b/packages/frontend/features/swap-tokens/useDustCanSwapAmount.ts
@@ -1,0 +1,45 @@
+import { ethers } from "ethers";
+
+const useDustCanSwapAmount = async (
+  thingToClear: string,
+  proxyAddress: string,
+  cTokenAddress: string,
+  tokenBalance: string,
+  decimals: number,
+  compoundComptroller: ethers.Contract,
+  compoundPriceOracle: ethers.Contract
+): Promise<any> => {
+  // Calculate MAX borrowing supply
+  const accountLiquidity = await compoundComptroller.getAccountLiquidity(
+    proxyAddress
+  );
+  const liquidity = accountLiquidity[1];
+
+  if (liquidity.lte(0)) {
+    return { canSwapAmount: 0 };
+  }
+
+  const cTokenPrice = await compoundPriceOracle.getUnderlyingPrice(
+    cTokenAddress
+  );
+
+  const wei18 = ethers.utils.parseEther("1");
+  const maxBorrowAmountWei = liquidity.mul(wei18).div(cTokenPrice);
+
+  // Swapping debt should be done 100% via flashloans
+  // However, you can only swap 95% of your debt because of slippages
+  const maxBorrowAmountWeiFixed =
+    thingToClear === "debt"
+      ? maxBorrowAmountWei.mul(95).div(100)
+      : maxBorrowAmountWei;
+    
+  const maxBorrowAmount = ethers.utils.formatUnits(maxBorrowAmountWeiFixed, decimals)
+
+  const canSwapAmount = parseFloat(maxBorrowAmount) > parseFloat(tokenBalance)
+    ? tokenBalance
+    : maxBorrowAmount;
+
+  return { canSwapAmount };
+};
+
+export default useDustCanSwapAmount;

--- a/packages/money-legos/abi/compound/CompoundPriceOracle.json
+++ b/packages/money-legos/abi/compound/CompoundPriceOracle.json
@@ -1,552 +1,110 @@
 [
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "anchorAdmin",
-        "outputs": [
-            {
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "maxSwingMantissa",
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "name": "_assetPrices",
-        "outputs": [
-            {
-                "name": "mantissa",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "pendingAnchorAdmin",
-        "outputs": [
-            {
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "numBlocksPerPeriod",
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "name": "readers",
-        "outputs": [
-            {
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "paused",
-        "outputs": [
-            {
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "name": "anchors",
-        "outputs": [
-            {
-                "name": "period",
-                "type": "uint256"
-            },
-            {
-                "name": "priceMantissa",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "poster",
-        "outputs": [
-            {
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "name": "pendingAnchors",
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "maxSwing",
-        "outputs": [
-            {
-                "name": "mantissa",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "name": "_poster",
-                "type": "address"
-            },
-            {
-                "name": "addr0",
-                "type": "address"
-            },
-            {
-                "name": "reader0",
-                "type": "address"
-            },
-            {
-                "name": "addr1",
-                "type": "address"
-            },
-            {
-                "name": "reader1",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
-        "payable": true,
-        "stateMutability": "payable",
-        "type": "fallback"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "name": "msgSender",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "name": "asset",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "name": "error",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "name": "info",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "name": "detail",
-                "type": "uint256"
-            }
-        ],
-        "name": "OracleFailure",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "name": "anchorAdmin",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "name": "asset",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "name": "oldScaledPrice",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "name": "newScaledPrice",
-                "type": "uint256"
-            }
-        ],
-        "name": "NewPendingAnchor",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "name": "asset",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "name": "previousPriceMantissa",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "name": "requestedPriceMantissa",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "name": "newPriceMantissa",
-                "type": "uint256"
-            }
-        ],
-        "name": "PricePosted",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "name": "asset",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "name": "requestedPriceMantissa",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "name": "anchorPriceMantissa",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "name": "cappedPriceMantissa",
-                "type": "uint256"
-            }
-        ],
-        "name": "CappedPricePosted",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "name": "newState",
-                "type": "bool"
-            }
-        ],
-        "name": "SetPaused",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "name": "oldPendingAnchorAdmin",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "name": "newPendingAnchorAdmin",
-                "type": "address"
-            }
-        ],
-        "name": "NewPendingAnchorAdmin",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "name": "oldAnchorAdmin",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "name": "newAnchorAdmin",
-                "type": "address"
-            }
-        ],
-        "name": "NewAnchorAdmin",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "name": "error",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "name": "info",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "name": "detail",
-                "type": "uint256"
-            }
-        ],
-        "name": "Failure",
-        "type": "event"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "name": "asset",
-                "type": "address"
-            },
-            {
-                "name": "newScaledPrice",
-                "type": "uint256"
-            }
-        ],
-        "name": "_setPendingAnchor",
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "name": "requestedState",
-                "type": "bool"
-            }
-        ],
-        "name": "_setPaused",
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "name": "newPendingAnchorAdmin",
-                "type": "address"
-            }
-        ],
-        "name": "_setPendingAnchorAdmin",
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [],
-        "name": "_acceptAnchorAdmin",
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "name": "asset",
-                "type": "address"
-            }
-        ],
-        "name": "assetPrices",
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "name": "asset",
-                "type": "address"
-            }
-        ],
-        "name": "getPrice",
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "name": "asset",
-                "type": "address"
-            },
-            {
-                "name": "requestedPriceMantissa",
-                "type": "uint256"
-            }
-        ],
-        "name": "setPrice",
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "name": "assets",
-                "type": "address[]"
-            },
-            {
-                "name": "requestedPriceMantissas",
-                "type": "uint256[]"
-            }
-        ],
-        "name": "setPrices",
-        "outputs": [
-            {
-                "name": "",
-                "type": "uint256[]"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    }
+  {
+    "inputs": [
+      { "internalType": "address", "name": "comptroller_", "type": "address" },
+      {
+        "internalType": "address",
+        "name": "v1PriceOracle_",
+        "type": "address"
+      },
+      { "internalType": "address", "name": "cEthAddress_", "type": "address" },
+      { "internalType": "address", "name": "cUsdcAddress_", "type": "address" },
+      { "internalType": "address", "name": "cSaiAddress_", "type": "address" },
+      { "internalType": "address", "name": "cDaiAddress_", "type": "address" }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "cDaiAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "cEthAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "cSaiAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "cUsdcAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "comptroller",
+    "outputs": [
+      { "internalType": "contract Comptroller", "name": "", "type": "address" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "contract CToken", "name": "cToken", "type": "address" }
+    ],
+    "name": "getUnderlyingPrice",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isPriceOracle",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "makerUsdOracleKey",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "v1PriceOracle",
+    "outputs": [
+      {
+        "internalType": "contract V1PriceOracleInterface",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
 ]

--- a/packages/smart-contracts/helpers/compound.ts
+++ b/packages/smart-contracts/helpers/compound.ts
@@ -490,6 +490,52 @@ const repayThroughProxy = async (
   return dacProxy.execute(dedgeCompoundManager, calldata, newOverrides);
 };
 
+const clearDustCollateral = async (
+  dacProxy: ethers.Contract,
+  dedgeCompoundManager: Address,
+  addressRegistry: Address,
+  oldCToken: Address,
+  amountWei: BigNumber,
+  newCToken: Address,
+  overrides: any = { gasLimit: 1500000 }
+) => {
+  const clearDustCollateralCallback = IDedgeCompoundManager.functions.clearCollateralDust.encode(
+    [addressRegistry, oldCToken, amountWei, newCToken]
+  );
+
+  const gasPrice = await getCustomGasPrice(dacProxy.provider);
+  const newOverrides = Object.assign({ gasPrice }, overrides);
+
+  return dacProxy.execute(
+    dedgeCompoundManager,
+    clearDustCollateralCallback,
+    newOverrides
+  );
+};
+
+const clearDustDebt = async (
+  dacProxy: ethers.Contract,
+  dedgeCompoundManager: Address,
+  addressRegistry: Address,
+  oldCToken: Address,
+  amountWei: BigNumber,
+  newCToken: Address,
+  overrides: any = { gasLimit: 1500000 }
+) => {
+  const clearDustDebtCallback = IDedgeCompoundManager.functions.clearDebtDust.encode(
+    [addressRegistry, oldCToken, amountWei, newCToken]
+  );
+
+  const gasPrice = await getCustomGasPrice(dacProxy.provider);
+  const newOverrides = Object.assign({ gasPrice }, overrides);
+
+  return dacProxy.execute(
+    dedgeCompoundManager,
+    clearDustDebtCallback,
+    newOverrides
+  );
+};
+
 export default {
   swapCollateral,
   swapDebt,
@@ -503,5 +549,7 @@ export default {
   borrowThroughProxy,
   withdrawThroughProxy,
   repayThroughProxy,
+  clearDustCollateral,
+  clearDustDebt,
   CTOKEN_ACTIONS,
 };


### PR DESCRIPTION
Added option to clear collateral/debt dust.

Difference between clearing dust and swapping is that clearing "dust" ultilizes your borrowing power instead of aave flash loans to swap collateral/deb into your target collateral/debt. It's main usage isto change your left-over collateral after using flash loans (as you can only swap a max of 95% collateral at any given time, due to slippages)
