### PR TITLE
Refactor frontend: exit position

### DIFF
--- a/packages/frontend/features/exit-position/ExitPosition.tsx
+++ b/packages/frontend/features/exit-position/ExitPosition.tsx
@@ -1,38 +1,10 @@
 import { useState } from "react";
-import {
-  Box,
-  Flex,
-  Loader,
-  Modal,
-  Text,
-  Button,
-  Heading,
-  Card,
-} from "rimble-ui";
+import { Box, Button } from "rimble-ui";
 
-// components
-import { ModalBottom, ModalCloseIcon } from "../../components/Modal";
-
-// containers
-import ContractsContainer from "../../containers/Contracts";
-import ConnectionContainer from "../../containers/Connection";
-import DACProxyContainer from "../../containers/DACProxy";
-import CompoundPositions from "../../containers/CompoundPositions";
-
-import { dedgeHelpers } from "../../../smart-contracts/dist/helpers";
+import ExitPositionModal from "./ExitPositionModal";
 
 const ExitPositionsButton = () => {
-  const { address, signer } = ConnectionContainer.useContainer();
-  const { getBalances } = CompoundPositions.useContainer();
-  const { contracts } = ContractsContainer.useContainer();
-  const { proxy } = DACProxyContainer.useContainer();
-
-  // state
   const [isOpen, setIsOpen] = useState(false);
-  const [selectedVaultId, setSelectedVaultId] = useState(null);
-
-  // hooks
-  const [loading, setLoading] = useState(false);
 
   const closeModal = () => setIsOpen(false);
   const openModal = () => setIsOpen(true);
@@ -48,107 +20,7 @@ const ExitPositionsButton = () => {
         Exit Positions
       </Button>
 
-      <Modal isOpen={isOpen}>
-        <Card width={"640px"} p={0}>
-          <ModalCloseIcon onClick={closeModal} />
-
-          <Box p={4}>
-            <Heading.h3 mb="4">Exit Positions</Heading.h3>
-
-            <Box mb="4">
-              <Heading.h5 mb="2">Please confirm that you want to:</Heading.h5>
-              <Text>
-                This will exit both supplied and borrowed positions and convert
-                them into ETH
-              </Text>
-            </Box>
-
-            <Box>
-              <Text fontSize="0" color="#999">
-                Service Fee: 0.135% (0.09% to AAVE for flash loan)
-              </Text>
-            </Box>
-          </Box>
-
-          <ModalBottom>
-            <Button.Outline onClick={closeModal}>Close</Button.Outline>
-            <Button
-              ml={3}
-              disabled={loading}
-              onClick={async () => {
-                window.analytics.track("Exit Positions Start");
-                setLoading(true);
-
-                const { dedgeAddressRegistry, dedgeExitManager } = contracts;
-
-                const {
-                  etherToBorrowWeiBN,
-                  debtMarkets,
-                  collateralMarkets,
-                } = await dedgeHelpers.exit.getExitPositionParameters(
-                  signer,
-                  proxy.address
-                );
-
-                let tx = null;
-                try {
-                  tx = await dedgeHelpers.exit.exitPositionToETH(
-                    address,
-                    etherToBorrowWeiBN,
-                    proxy,
-                    dedgeAddressRegistry.address,
-                    dedgeExitManager.address,
-                    debtMarkets,
-                    collateralMarkets
-                  );
-                  window.toastProvider.addMessage(`Exiting positions...`, {
-                    secondaryMessage: "Check progress on Etherscan",
-                    actionHref: `https://etherscan.io/tx/${tx.hash}`,
-                    actionText: "Check",
-                    variant: "processing",
-                  });
-                  await tx.wait();
-
-                  window.toastProvider.addMessage(`Exited Positions!`, {
-                    variant: "success",
-                  });
-                } catch (e) {
-                  if (tx === null) {
-                    window.toastProvider.addMessage(`Transaction cancelled`, {
-                      variant: "failure",
-                    });
-                  } else {
-                    window.toastProvider.addMessage(
-                      `Failed to exit poisitions...`,
-                      {
-                        secondaryMessage: "Check reason on Etherscan",
-                        actionHref: `https://etherscan.io/tx/${tx.hash}`,
-                        actionText: "Check",
-                        variant: "failure",
-                      }
-                    );
-                  }
-                  setLoading(false);
-                  return;
-                }
-
-                window.analytics.track("Exit Positions Success");
-                setLoading(false);
-                getBalances();
-                closeModal();
-              }}
-            >
-              {loading ? (
-                <Flex alignItems="center">
-                  <span>Exiting...</span> <Loader color="white" ml="2" />
-                </Flex>
-              ) : (
-                "Exit Position"
-              )}
-            </Button>
-          </ModalBottom>
-        </Card>
-      </Modal>
+      <ExitPositionModal isOpen={isOpen} closeModal={closeModal} />
     </Box>
   );
 };

--- a/packages/frontend/features/exit-position/ExitPositionModal.tsx
+++ b/packages/frontend/features/exit-position/ExitPositionModal.tsx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import {
+  Box,
+  Flex,
+  Loader,
+  Modal,
+  Text,
+  Button,
+  Heading,
+  Card,
+} from "rimble-ui";
+
+// components
+import { ModalBottom, ModalCloseIcon } from "../../components/Modal";
+
+// containers
+import ContractsContainer from "../../containers/Contracts";
+import ConnectionContainer from "../../containers/Connection";
+import DACProxyContainer from "../../containers/DACProxy";
+import CompoundPositions from "../../containers/CompoundPositions";
+
+import { dedgeHelpers } from "../../../smart-contracts/dist/helpers";
+
+const ExitPositionModal = ({ isOpen, closeModal }) => {
+  const { address, signer } = ConnectionContainer.useContainer();
+  const { getBalances } = CompoundPositions.useContainer();
+  const { contracts } = ContractsContainer.useContainer();
+  const { proxy } = DACProxyContainer.useContainer();
+
+  // hooks
+  const [loading, setLoading] = useState(false);
+
+  return (
+    <Modal isOpen={isOpen}>
+      <Card width={"640px"} p={0}>
+        <ModalCloseIcon onClick={closeModal} />
+
+        <Box p={4}>
+          <Heading.h3 mb="4">Exit Positions</Heading.h3>
+
+          <Box mb="4">
+            <Heading.h5 mb="2">Please confirm that you want to:</Heading.h5>
+            <Text>
+              This will exit both supplied and borrowed positions and convert
+              them into ETH
+            </Text>
+          </Box>
+
+          <Box>
+            <Text fontSize="0" color="#999">
+              Service Fee: 0.135% (0.09% to AAVE for flash loan)
+            </Text>
+          </Box>
+        </Box>
+
+        <ModalBottom>
+          <Button.Outline onClick={closeModal}>Close</Button.Outline>
+          <Button
+            ml={3}
+            disabled={loading}
+            onClick={async () => {
+              window.analytics.track("Exit Positions Start");
+              setLoading(true);
+
+              const { dedgeAddressRegistry, dedgeExitManager } = contracts;
+
+              const {
+                etherToBorrowWeiBN,
+                debtMarkets,
+                collateralMarkets,
+              } = await dedgeHelpers.exit.getExitPositionParameters(
+                signer,
+                proxy.address,
+              );
+
+              let tx = null;
+              try {
+                tx = await dedgeHelpers.exit.exitPositionToETH(
+                  address,
+                  etherToBorrowWeiBN,
+                  proxy,
+                  dedgeAddressRegistry.address,
+                  dedgeExitManager.address,
+                  debtMarkets,
+                  collateralMarkets,
+                );
+                window.toastProvider.addMessage(`Exiting positions...`, {
+                  secondaryMessage: "Check progress on Etherscan",
+                  actionHref: `https://etherscan.io/tx/${tx.hash}`,
+                  actionText: "Check",
+                  variant: "processing",
+                });
+                await tx.wait();
+
+                window.toastProvider.addMessage(`Exited Positions!`, {
+                  variant: "success",
+                });
+              } catch (e) {
+                if (tx === null) {
+                  window.toastProvider.addMessage(`Transaction cancelled`, {
+                    variant: "failure",
+                  });
+                } else {
+                  window.toastProvider.addMessage(
+                    `Failed to exit poisitions...`,
+                    {
+                      secondaryMessage: "Check reason on Etherscan",
+                      actionHref: `https://etherscan.io/tx/${tx.hash}`,
+                      actionText: "Check",
+                      variant: "failure",
+                    },
+                  );
+                }
+                setLoading(false);
+                return;
+              }
+
+              window.analytics.track("Exit Positions Success");
+              setLoading(false);
+              getBalances();
+              closeModal();
+            }}
+          >
+            {loading ? (
+              <Flex alignItems="center">
+                <span>Exiting...</span> <Loader color="white" ml="2" />
+              </Flex>
+            ) : (
+              "Exit Position"
+            )}
+          </Button>
+        </ModalBottom>
+      </Card>
+    </Modal>
+  );
+};
+
+export default ExitPositionModal;

--- a/packages/frontend/features/exit-position/useExitPosition.ts
+++ b/packages/frontend/features/exit-position/useExitPosition.ts
@@ -1,0 +1,79 @@
+import ContractsContainer from "../../containers/Contracts";
+import ConnectionContainer from "../../containers/Connection";
+import DACProxyContainer from "../../containers/DACProxy";
+import CompoundPositions from "../../containers/CompoundPositions";
+
+import { dedgeHelpers } from "../../../smart-contracts/dist/helpers";
+import { useState } from "react";
+
+const useExitPosition = () => {
+  const { address, signer } = ConnectionContainer.useContainer();
+  const { getBalances } = CompoundPositions.useContainer();
+  const { contracts } = ContractsContainer.useContainer();
+  const { proxy } = DACProxyContainer.useContainer();
+
+  const [loading, setLoading] = useState(false);
+
+  const exitPosition = async () => {
+    window.analytics.track("Exit Positions Start");
+    setLoading(true);
+
+    const { dedgeAddressRegistry, dedgeExitManager } = contracts;
+
+    const {
+      etherToBorrowWeiBN,
+      debtMarkets,
+      collateralMarkets,
+    } = await dedgeHelpers.exit.getExitPositionParameters(
+      signer,
+      proxy.address,
+    );
+
+    let tx = null;
+    try {
+      tx = await dedgeHelpers.exit.exitPositionToETH(
+        address,
+        etherToBorrowWeiBN,
+        proxy,
+        dedgeAddressRegistry.address,
+        dedgeExitManager.address,
+        debtMarkets,
+        collateralMarkets,
+      );
+      window.toastProvider.addMessage(`Exiting positions...`, {
+        secondaryMessage: "Check progress on Etherscan",
+        actionHref: `https://etherscan.io/tx/${tx.hash}`,
+        actionText: "Check",
+        variant: "processing",
+      });
+      await tx.wait();
+
+      window.toastProvider.addMessage(`Exited Positions!`, {
+        variant: "success",
+      });
+    } catch (e) {
+      if (tx === null) {
+        window.toastProvider.addMessage(`Transaction cancelled`, {
+          variant: "failure",
+        });
+      } else {
+        window.toastProvider.addMessage(`Failed to exit poisitions...`, {
+          secondaryMessage: "Check reason on Etherscan",
+          actionHref: `https://etherscan.io/tx/${tx.hash}`,
+          actionText: "Check",
+          variant: "failure",
+        });
+      }
+      setLoading(false);
+      return;
+    }
+
+    window.analytics.track("Exit Positions Success");
+    setLoading(false);
+    getBalances();
+  };
+
+  return { exitPosition, loading };
+};
+
+export default useExitPosition;

--- a/packages/frontend/features/exit-position/useExitPositionToEth.ts
+++ b/packages/frontend/features/exit-position/useExitPositionToEth.ts
@@ -1,0 +1,35 @@
+import ConnectionContainer from "../../containers/Connection";
+import DACProxyContainer from "../../containers/DACProxy";
+import ContractsContainer from "../../containers/Contracts";
+
+import { dedgeHelpers } from "../../../smart-contracts/dist/helpers";
+
+const useExitPositionToEth = () => {
+  const { address } = ConnectionContainer.useContainer();
+  const { contracts } = ContractsContainer.useContainer();
+  const { proxy } = DACProxyContainer.useContainer();
+
+  const { dedgeAddressRegistry, dedgeExitManager } = contracts;
+
+  const exitPositionToEth = async (
+    etherToBorrowWeiBN,
+    debtMarkets,
+    collateralMarkets,
+  ) => {
+    const tx = await dedgeHelpers.exit.exitPositionToETH(
+      address,
+      etherToBorrowWeiBN,
+      proxy,
+      dedgeAddressRegistry.address,
+      dedgeExitManager.address,
+      debtMarkets,
+      collateralMarkets,
+    );
+
+    return tx;
+  };
+
+  return { exitPositionToEth };
+};
+
+export default useExitPositionToEth;

--- a/packages/frontend/features/exit-position/useGetExitParams.ts
+++ b/packages/frontend/features/exit-position/useGetExitParams.ts
@@ -1,0 +1,26 @@
+import ConnectionContainer from "../../containers/Connection";
+import DACProxyContainer from "../../containers/DACProxy";
+
+import { dedgeHelpers } from "../../../smart-contracts/dist/helpers";
+
+const useGetExitParams = () => {
+  const { signer } = ConnectionContainer.useContainer();
+  const { proxy } = DACProxyContainer.useContainer();
+
+  const getExitParams = async () => {
+    const {
+      etherToBorrowWeiBN,
+      debtMarkets,
+      collateralMarkets,
+    } = await dedgeHelpers.exit.getExitPositionParameters(
+      signer,
+      proxy.address,
+    );
+
+    return { etherToBorrowWeiBN, debtMarkets, collateralMarkets };
+  };
+
+  return { getExitParams };
+};
+
+export default useGetExitParams;


### PR DESCRIPTION
I split the `ExitPosition.tsx` file into 5 different files. You can take a look at each commit to see what I extracted out.

Here's a brief explanation of how I did it and why:

1. First, I moved the modal stuff to its own file because when you are working with just the button placement, you don't care about what's inside the modal.
2. Then I created a custom hook called `useExitPosition.ts` to remove all business logic from the component files.
3. There are two steps in the exit position flow: (1) `getExitPositionParameters` and then (2) `exitPositionToEth `. These two steps were split out into their own files and they can import the containers by themselves.

Which means `useExitPosition.ts` become much cleaner, because it only requires one container (to get the balances after everything is done). The toasts were also adding a lot of visual noise so I moved them down to their own functions, but this is not completely necessary.

Note that the `.tsx` files are all component files because they have JSX inside them. The `.ts` files are the hooks encapsulating business logic.

- `.tsx` files should not have any business logic inside them, it should be purely concerned with display only.
- `.ts` files should not have any display logic inside them (i.e. `closeModal`) and should be purely about business logic. Even if we significantly change the design of the dapp, nothing inside this file should change.